### PR TITLE
Custom functions

### DIFF
--- a/lib/processable_services/application_service.rb
+++ b/lib/processable_services/application_service.rb
@@ -3,8 +3,8 @@
 module ProcessableServices
   class ApplicationService
 
-    def self.call(*args, &block)
-      new(*args, &block).call
+    def self.call(*args, **options, &block)
+      new(*args, **options, &block).call
     end
   end
 end

--- a/lib/processable_services/decision_evaluator.js
+++ b/lib/processable_services/decision_evaluator.js
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
 const { decisionTable } = require("@connectedbits/dmn-eval-js")
+const parseCustomFunctions = require("./parse_custom_functions")
 
 var args = process.argv.slice(2)
 
 const decisionId = args[0]
 const source = args[1]
 const context = JSON.parse(args[2])
+Object.assign(context, parseCustomFunctions(args.slice(3)))
 
 const evaluateDecision = async (source) => {
   decisionTable.parseDmnXml(source).then((decisions) => {

--- a/lib/processable_services/decision_evaluator.rb
+++ b/lib/processable_services/decision_evaluator.rb
@@ -4,15 +4,16 @@ module ProcessableServices
   class DecisionEvaluator < ApplicationService
     EVALUATE_BIN = File.expand_path(File.dirname(__FILE__)) + "/decision_evaluator.js"
 
-    def initialize(decision_id, source, context)
+    def initialize(decision_id, source, context, functions: [])
       super()
       @decision_id = decision_id
       @source = source
       @context = context
+      @functions = functions
     end
 
     def call
-      command = [EVALUATE_BIN, @decision_id, @source, @context.to_json].shelljoin
+      command = [EVALUATE_BIN, @decision_id, @source, @context.to_json, *@functions].shelljoin
       result = `#{command}`
       if $? == 0
         JSON.parse(result)

--- a/lib/processable_services/feel_evaluator.js
+++ b/lib/processable_services/feel_evaluator.js
@@ -5,11 +5,11 @@ const { feel } = require("js-feel")()
 var args = process.argv.slice(2)
 
 const expression = args[0]
-const variables = JSON.parse(args[1])
+const context = JSON.parse(args[1])
 
 const parsedGrammar = feel.parse(expression)
 
-parsedGrammar.build(variables).then(result => {
+parsedGrammar.build(context).then(result => {
   console.log(result)
   process.exit(0)
 }).catch(err => {

--- a/lib/processable_services/feel_evaluator.js
+++ b/lib/processable_services/feel_evaluator.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
 const { feel } = require("js-feel")()
+const parseCustomFunctions = require("./parse_custom_functions")
 
 var args = process.argv.slice(2)
 
 const expression = args[0]
 const context = JSON.parse(args[1])
+Object.assign(context, parseCustomFunctions(args.slice(2)))
 
 const parsedGrammar = feel.parse(expression)
 

--- a/lib/processable_services/feel_evaluator.rb
+++ b/lib/processable_services/feel_evaluator.rb
@@ -4,20 +4,21 @@ module ProcessableServices
   class FeelEvaluator
     FEEL_EVALUATOR_BIN = File.expand_path(File.dirname(__FILE__)) + "/feel_evaluator.js"
 
-    attr_reader :expression, :variables
+    attr_reader :expression, :variables, :functions
 
-    def self.call(expression:, variables:)
-      new(expression: expression, variables: variables).call
+    def self.call(expression:, variables:, functions: [])
+      new(expression: expression, variables: variables, functions: functions).call
     end
 
-    def initialize(expression:, variables: {})
+    def initialize(expression:, variables: {}, functions: [])
       super()
       @expression = expression
       @variables = variables
+      @functions = functions
     end
 
     def call
-      command = [FEEL_EVALUATOR_BIN, expression, variables.to_json].shelljoin
+      command = [FEEL_EVALUATOR_BIN, expression, variables.to_json, *functions].shelljoin
       result = `#{command}`
       JSON.parse(result)
     rescue JSON::ParserError

--- a/lib/processable_services/parse_custom_functions.js
+++ b/lib/processable_services/parse_custom_functions.js
@@ -1,0 +1,13 @@
+module.exports = function(files_or_strings) {
+  var output = {}
+  for (const arg of files_or_strings) {
+    var functions
+    if (arg[0] == "/") {
+      functions = require(arg)
+    } else {
+      functions = eval(arg)
+    }
+    output = Object.assign(output, functions)
+  }
+  return output
+}

--- a/test/fixtures/files/custom_functions.dmn
+++ b/test/fixtures/files/custom_functions.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_ChooseGreeting" name="Custom Functions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.8.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_CustomFunctions" name="Custom Functions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.8.0">
   <decision id="output" name="Output">
     <decisionTable id="DecisionTable_1x25309">
       <input id="Input_1" label="Language">
@@ -20,7 +20,7 @@
   </decision>
   <dmndi:DMNDI>
     <dmndi:DMNDiagram>
-      <dmndi:DMNShape dmnElementRef="ChooseGreeting">
+      <dmndi:DMNShape dmnElementRef="CustomFunctions">
         <dc:Bounds height="80" width="180" x="160" y="100" />
       </dmndi:DMNShape>
     </dmndi:DMNDiagram>

--- a/test/fixtures/files/custom_functions.dmn
+++ b/test/fixtures/files/custom_functions.dmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_ChooseGreeting" name="Custom Functions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.8.0">
+  <decision id="output" name="Output">
+    <decisionTable id="DecisionTable_1x25309">
+      <input id="Input_1" label="Language">
+        <inputExpression id="InputExpression_1" typeRef="string">
+          <text>point</text>
+        </inputExpression>
+      </input>
+      <output id="Output_1" label="format datetime()" name="format datetime" typeRef="string" />
+      <rule id="DecisionRule_0tog1vl">
+        <inputEntry id="UnaryTests_16e20ig">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0gsyiyp">
+          <text>format datetime(date and time(point), 'YYYY-MM-DD hh:mm:ss a')</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="ChooseGreeting">
+        <dc:Bounds height="80" width="180" x="160" y="100" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/test/fixtures/files/custom_functions.js
+++ b/test/fixtures/files/custom_functions.js
@@ -1,0 +1,12 @@
+function blah(arg1) {
+  return "blah blah blah"
+}
+
+function formatDateTime(time, format) {
+  return time.format(format)
+}
+
+module.exports = {
+  "blah":            blah,
+  "format datetime": formatDateTime,
+}

--- a/test/processable_services/decision_evaluator_test.rb
+++ b/test/processable_services/decision_evaluator_test.rb
@@ -58,5 +58,41 @@ module ProcessableServices
         end
       end
     end
+
+    describe(:custom_functions_as_file) do
+      let(:source) { fixture_source("custom_functions.dmn") }
+      let(:decision_name) { "output" }
+
+      describe :evaluate do
+        let(:context) {
+          {
+            point: Time.new(2001, 2, 3, 4, 5, 11, "+00:00"),
+          }
+        }
+        let(:result) { DecisionEvaluator.call(decision_name, source, context, functions: file_fixture("custom_functions.js")) }
+
+        it "should correctly parse and eval a dmn rule" do
+          _(result).must_equal("format datetime" => "2001-02-03 04:05:11 am")
+        end
+      end
+    end
+
+    describe(:custom_functions_as_string) do
+      let(:source) { fixture_source("custom_functions.dmn") }
+      let(:decision_name) { "output" }
+
+      describe :evaluate do
+        let(:context) {
+          {
+            point: Time.new(2001, 2, 3, 4, 5, 11, "+00:00"),
+          }
+        }
+        let(:result) { DecisionEvaluator.call(decision_name, source, context, functions: file_fixture("custom_functions.js").read) }
+
+        it "should correctly parse and eval a dmn rule" do
+          _(result).must_equal("format datetime" => "2001-02-03 04:05:11 am")
+        end
+      end
+    end
   end
 end

--- a/test/processable_services/feel_evaluator_test.rb
+++ b/test/processable_services/feel_evaluator_test.rb
@@ -54,5 +54,25 @@ module ProcessableServices
         _(result).must_equal("ABC123")
       end
     end
+
+    describe :custom_functions_as_file do
+      let(:expression) { "format datetime(date and time(point), 'YYYY-MM-DD hh:mm:ss a')" }
+      let(:variables) { { point: Time.new(2001, 2, 3, 4, 5, 11, "+00:00") } }
+      let(:result) { service.call(expression: expression, variables: variables, functions: file_fixture("custom_functions.js")) }
+
+      it "should format time" do
+        _(result).must_equal("2001-02-03 04:05:11 am")
+      end
+    end
+
+    describe :custom_functions_as_string do
+      let(:expression) { "format datetime(date and time(point), 'YYYY-MM-DD hh:mm:ss a')" }
+      let(:variables) { { point: Time.new(2001, 2, 3, 4, 5, 11, "+00:00") } }
+      let(:result) { service.call(expression: expression, variables: variables, functions: fixture_source("custom_functions.js")) }
+
+      it "should format time" do
+        _(result).must_equal("2001-02-03 04:05:11 am")
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow dynamic extension of the FEEL runtime environment via custom functions. The CLI and Ruby interfaces for `FeelEvaluator` and `DecisionEvaluator` now accept a list of JavaScript filenames or strings to be added to context as custom functions callable from FEEL.

See tests for more through examples, but here's a serious but simple example:

```ruby
functions = '
  module.exports = {
    "format datetime": function(time, format) {
      return time.format(format)
    },
  }
'
expression = "format datetime(date and time(point), 'YYYY-MM-DD hh:mm:ss a')"
variables = { point: Time.new(2001, 2, 3, 4, 5, 11, "+00:00") }
ProcessableServices::FeelEvaluator.call(expression:, variables:, functions:)
# => "2001-02-03 04:05:11 am"
```