### PR TITLE
Caller process control

### DIFF
--- a/lib/processable_services/application_service.rb
+++ b/lib/processable_services/application_service.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
+require_relative "./process_executor"
 
 module ProcessableServices
   class ApplicationService
+    include ProcessExecutor
 
     def self.call(*args, **options, &block)
       new(*args, **options, &block).call

--- a/lib/processable_services/decision_evaluator.rb
+++ b/lib/processable_services/decision_evaluator.rb
@@ -4,22 +4,17 @@ module ProcessableServices
   class DecisionEvaluator < ApplicationService
     EVALUATE_BIN = File.expand_path(File.dirname(__FILE__)) + "/decision_evaluator.js"
 
-    def initialize(decision_id, source, context, functions: [])
+    def initialize(decision_id, source, context, functions: [], env: nil)
       super()
       @decision_id = decision_id
       @source = source
       @context = context
       @functions = functions
+      @env = env
     end
 
     def call
-      command = [EVALUATE_BIN, @decision_id, @source, @context.to_json, *@functions].shelljoin
-      result = `#{command}`
-      if $? == 0
-        JSON.parse(result)
-      else
-        raise result
-      end
+      execute_json_process(EVALUATE_BIN, @decision_id, @source, @context.to_json, *@functions, env: @env)
     end
   end
 end

--- a/lib/processable_services/decision_reader.rb
+++ b/lib/processable_services/decision_reader.rb
@@ -4,15 +4,14 @@ module ProcessableServices
   class DecisionReader < ApplicationService
     DECISION_READER_BIN = File.expand_path(File.dirname(__FILE__)) + "/decision_reader.js"
 
-    def initialize(source)
+    def initialize(source, env: nil)
       super()
       @source = source
+      @env = env
     end
 
     def call
-      command = [DECISION_READER_BIN, @source].shelljoin
-      result = `#{command}`
-      JSON.parse(result)
+      execute_json_process(DECISION_READER_BIN, @source, env: @env)
     end
   end
 end

--- a/lib/processable_services/feel_evaluator.rb
+++ b/lib/processable_services/feel_evaluator.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
-
+require_relative "./process_executor"
 module ProcessableServices
   class FeelEvaluator
+    include ProcessExecutor
+
     FEEL_EVALUATOR_BIN = File.expand_path(File.dirname(__FILE__)) + "/feel_evaluator.js"
 
     attr_reader :expression, :variables, :functions
@@ -10,16 +12,16 @@ module ProcessableServices
       new(expression: expression, variables: variables, functions: functions).call
     end
 
-    def initialize(expression:, variables: {}, functions: [])
+    def initialize(expression:, variables: {}, functions: [], env: nil)
       super()
       @expression = expression
       @variables = variables
       @functions = functions
+      @env = env
     end
 
     def call
-      command = [FEEL_EVALUATOR_BIN, expression, variables.to_json, *functions].shelljoin
-      result = `#{command}`
+      result = execute_process(FEEL_EVALUATOR_BIN, expression, variables.to_json, *functions, env: @env)
       JSON.parse(result)
     rescue JSON::ParserError
       result.strip

--- a/lib/processable_services/process_executor.rb
+++ b/lib/processable_services/process_executor.rb
@@ -5,12 +5,14 @@ module ProcessableServices
 
     def execute_process(*args, env: nil)
       command = args.shelljoin
+
       r, w = IO.pipe
-      # This redirection occurs because we want the calling
-      # process to have a chance to display any extra information
-      # emitted via STDERR
       process_env = env || {}
       process_env["PATH"] ||= ENV["PATH"]
+
+      # The redirection of err to the STDERR of the owning process is to allow the
+      # caller process to have a chance to display any extra information emitted via STDERR
+      #
       # We also specifically drop any env vars that are not indicated by the caller
       # since we likely do not want to bleed any external information into the JS process
       pid = Process.spawn(process_env, command, unsetenv_others: true, out: w, err: STDERR)

--- a/lib/processable_services/process_executor.rb
+++ b/lib/processable_services/process_executor.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ProcessableServices
+  module ProcessExecutor
+
+    def execute_process(*args, env: nil)
+      command = args.shelljoin
+      r, w = IO.pipe
+      # This redirection occurs because we want the calling
+      # process to have a chance to display any extra information
+      # emitted via STDERR
+      process_env = env || {}
+      process_env["PATH"] ||= ENV["PATH"]
+      # We also specifically drop any env vars that are not indicated by the caller
+      # since we likely do not want to bleed any external information into the JS process
+      pid = Process.spawn(process_env, command, unsetenv_others: true, out: w, err: STDERR)
+      status = Process::Status.wait(pid)
+      w.close
+      stdout = r.read.chomp rescue nil
+      r.close
+      if status.success?
+        stdout
+      else
+        raise "#{command} failed, #{status}: #{stdout || "No output"}"
+      end
+    end
+
+    def execute_json_process(*args, env: nil)
+      JSON.parse(execute_process(*args, env: env))
+    end
+  end
+end

--- a/lib/processable_services/process_reader.rb
+++ b/lib/processable_services/process_reader.rb
@@ -4,15 +4,14 @@ module ProcessableServices
   class ProcessReader < ApplicationService
     PROCESS_READER_BIN = File.expand_path(File.dirname(__FILE__)) + "/process_reader.js"
 
-    def initialize(source)
+    def initialize(source, env: nil)
       super()
       @source = source
+      @env = env
     end
 
     def call
-      command = [PROCESS_READER_BIN, @source].shelljoin
-      result = `#{command}`
-      JSON.parse(result)
+      execute_json_process(PROCESS_READER_BIN, @source, env: @env)
     end
   end
 end

--- a/lib/processable_services/process_writer.rb
+++ b/lib/processable_services/process_writer.rb
@@ -4,15 +4,14 @@ module ProcessableServices
   class ProcessWriter < ApplicationService
     PROCESS_WRITER_BIN = File.expand_path(File.dirname(__FILE__)) + "/process_writer.js"
 
-    def initialize(moddle)
+    def initialize(moddle, env: nil)
       super()
       @moddle = moddle
+      @env = env
     end
 
     def call
-      command = [PROCESS_WRITER_BIN, @moddle].shelljoin
-      result = `#{command}`
-      JSON.parse(result)
+      execute_json_process(PROCESS_WRITER_BIN, @moddle, env: @env)
     end
 
     private


### PR DESCRIPTION
This PR allows callers of the Processable gem to specify environment variables ( notably `TZ` ), as well as receive information on `STDERR` about information from the node process that executes DMN decisions. This is helpful when debugging executions such that information about the environment can be emitted in the process that is triggering the execution.